### PR TITLE
Handle zero budget case in optimization

### DIFF
--- a/marketingmix.py
+++ b/marketingmix.py
@@ -2241,15 +2241,24 @@ class MMM_App:
                 )
                 
                 # Показываем текущий расход для сравнения
-                current_total = sum(st.session_state.data[ch].mean() for ch in st.session_state.selected_media)
+                current_total = sum(
+                    st.session_state.data[ch].mean()
+                    for ch in st.session_state.selected_media
+                )
                 st.info(f"💡 Текущие расходы: {current_total:,.0f} руб/месяц")
-                
-                if total_budget != current_total:
-                    change_pct = ((total_budget - current_total) / current_total * 100)
+
+                if current_total == 0:
+                    st.info("ℹ️ Нет данных о прошлых расходах. Изменение бюджета: 0%")
+                elif total_budget != current_total:
+                    change_pct = (
+                        (total_budget - current_total) / current_total * 100
+                    )
                     if change_pct > 0:
                         st.success(f"📈 Увеличение бюджета на {change_pct:.0f}%")
                     else:
-                        st.warning(f"📉 Сокращение бюджета на {abs(change_pct):.0f}%")
+                        st.warning(
+                            f"📉 Сокращение бюджета на {abs(change_pct):.0f}%"
+                        )
                 
             with col2:
                 st.subheader("🚧 Ограничения по каналам")


### PR DESCRIPTION
## Summary
- prevent divide by zero when optimizing budgets with no historical spend data
- show informative message when previous spend is missing

## Testing
- `python -m py_compile marketingmix.py`

------
https://chatgpt.com/codex/tasks/task_e_68416c99097c8327841d1921e615f2a5